### PR TITLE
Add capability to specify defaults at the payment gateway level

### DIFF
--- a/Service/Omnipay.php
+++ b/Service/Omnipay.php
@@ -42,12 +42,11 @@ class Omnipay
      * Returns an Omnipay gateway.
      *
      * @param string $key        Gateway key as defined in the config
-     * @param array  $parameters Custom gateway parameters. If set, any default parameters configured will be ignored.
      *
      * @throws \RuntimeException If no gateway is configured for the key
      * @return AbstractGateway
      */
-    public function get($key = null, $parameters = null)
+    public function get($key = null)
     {
         $config = $this->getConfig();
 
@@ -77,13 +76,13 @@ class Omnipay
         /** @var GatewayInterface $gateway */
         $gateway = $factory->create($gatewayName, $client);
 
-        if ($parameters) {
-            // Custom parameters have been specified, so use them
-            $gateway->initialize($parameters);
-
-        } elseif (isset($config[$key])) {
+        if (isset($config[$key])) {
             // Default parameters have been configured, so use them
             $combinedParameters = array_merge($this->getParametersByGatewayName($gatewayName), $config[$key]);
+            $gatewayName = strtolower($combinedParameters['gateway']);
+            if (isset($config['defaults'][$gatewayName])) {
+                $combinedParameters = array_merge($combinedParameters, $config['defaults'][$gatewayName]);
+            }
             $gateway->initialize($combinedParameters);
         }
 

--- a/Tests/Service/OmnipayTest.php
+++ b/Tests/Service/OmnipayTest.php
@@ -624,9 +624,6 @@ class OmnipayTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @requires function
-     */
     public function testCreateStripe()
     {
         if (!class_exists('Omnipay\\Stripe\\Gateway')) {
@@ -770,20 +767,19 @@ class OmnipayTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('abc123', $gateway->getApiKey(), 'API key should be take from the gateway with the same name');
     }
 
-    public function testGetWithParameters()
+    public function testShouldMergeDefaultParametersDefinedForTheGateway()
     {
         $config = array(
-            'omnipay.default' => 'my_gateway',
             'omnipay.my_gateway.gateway' => 'Stripe',
-            'omnipay.my_gateway.apiKey' => 'abc123'
+            'omnipay.defaults.stripe.apiKey' => 'xyz123'
         );
         $serviceContainer = $this->getServiceContainer($config);
         $service = $this->buildService(array('container' => $serviceContainer));
 
         /** @var StripeGateway $gateway */
-        $gateway = $service->get('my_gateway', array('apiKey' => 'xyz789'));
+        $gateway = $service->get('my_gateway');
         $this->assertInstanceOf('Omnipay\\Stripe\\Gateway', $gateway, 'The default gateway should return');
-        $this->assertEquals('xyz789', $gateway->getApiKey(), 'API key should be overridden');
+        $this->assertEquals('xyz123', $gateway->getApiKey());
     }
 
     public function testSetConfig()

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "psr/log": "1.0"
     },
     "require-dev": {
-        "omnipay/omnipay": "~2.0"
+        "omnipay/omnipay": "~2.0",
+        "phpunit/phpunit": "~4.5"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
These defaults can apply to multiple versions of the same gateway without
having to define them for each gateway.