### PR TITLE
Apply quotes to services.yml for SF3.0 support

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,6 +4,6 @@ parameters:
 services:
     omnipay:
         class: %omnipay.service.class%
-        arguments: [ @service_container, @logger ]
+        arguments: [ "@service_container", "@logger" ]
         tags:
               - { name: monolog.logger, channel: omnipay }


### PR DESCRIPTION
Referring to @-services without quotes has been deprecated in SF2.8
and will return parse errors in 3.0