### PR TITLE
Ensure default log value is set if not provided

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,7 +18,9 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('omnipay');
         $rootNode->children()
-            ->arrayNode('log')->children()
+            ->arrayNode('log')
+            ->addDefaultsIfNotSet()
+            ->children()
                 ->scalarNode('format')
                     ->defaultValue(MessageFormatter::DEBUG_FORMAT);
 

--- a/Tests/Service/OmnipayTest.php
+++ b/Tests/Service/OmnipayTest.php
@@ -805,7 +805,9 @@ class OmnipayTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultBundleConfig()
     {
-        $containerBuilder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(array('setParameter'))
+            ->getMock();
 
         $containerBuilder
             ->expects($this->at(0)) // Values get set before YAML config is loaded
@@ -826,7 +828,9 @@ class OmnipayTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $containerBuilder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(array('setParameter'))
+            ->getMock();
 
         $containerBuilder
             ->expects($this->at(0)) // Values get set before YAML config is loaded

--- a/Tests/Service/OmnipayTest.php
+++ b/Tests/Service/OmnipayTest.php
@@ -5,6 +5,7 @@ namespace Xola\OmnipayBundle\Tests\Service;
 use Guzzle\Log\MessageFormatter;
 use Omnipay\Stripe\Gateway as StripeGateway;
 use Xola\OmnipayBundle\Service\Omnipay;
+use Xola\OmnipayBundle\DependencyInjection\OmnipayExtension;
 
 class OmnipayTest extends \PHPUnit_Framework_TestCase
 {
@@ -800,5 +801,39 @@ class OmnipayTest extends \PHPUnit_Framework_TestCase
         $service->setConfig('my_gateway', array('apiKey' => 'xyz789'));
         $serviceConfig = $service->getConfig();
         $this->assertEquals('xyz789', $serviceConfig['my_gateway']['apiKey'], 'API key should be updated');
+    }
+
+    public function testDefaultBundleConfig()
+    {
+        $containerBuilder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+
+        $containerBuilder
+            ->expects($this->at(0)) // Values get set before YAML config is loaded
+            ->method('setParameter')
+            ->with('omnipay.log.format', MessageFormatter::DEBUG_FORMAT);
+
+        $extension = new OmnipayExtension();
+        $extension->load(array(), $containerBuilder);
+    }
+
+    public function testSetBundleConfig()
+    {
+        $config = array(
+            array(
+                'log' => array(
+                    'format' => 'abc123'
+                )
+            )
+        );
+
+        $containerBuilder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+
+        $containerBuilder
+            ->expects($this->at(0)) // Values get set before YAML config is loaded
+            ->method('setParameter')
+            ->with('omnipay.log.format', 'abc123');
+
+        $extension = new OmnipayExtension();
+        $extension->load($config, $containerBuilder);
     }
 }


### PR DESCRIPTION
The default value for the log configuration wasn't being set properly, which would cause exceptions in dev mode.

Fixes #9 