### PR TITLE
PL-916 [Vanta] Remediate High vulnerabilities in packages — PHP floor >=7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 7.2
-  - 7.3
   - 7.4
 
 env:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "homepage": "https://github.com/xola/OmnipayBundle",
     "license": "MIT",
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "symfony/framework-bundle": ">=2.1",
         "league/omnipay": "^3.0",
         "php-http/logger-plugin": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "homepage": "https://github.com/xola/OmnipayBundle",
     "license": "MIT",
     "require": {
-        "php": ">=7",
+        "php": ">=7.2",
         "symfony/framework-bundle": ">=2.1",
         "league/omnipay": "^3.0",
         "php-http/logger-plugin": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php-http/logger-plugin": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6",
+        "phpunit/phpunit": "^8.5.52",
         "omnipay/authorizenet": "^3.3",
         "omnipay/eway": "^3.0",
         "omnipay/mollie": "^5.2",


### PR DESCRIPTION
## Summary

Replaces #14. Same goal — clear the single open **high** Dependabot alert by raising the `phpunit/phpunit` dev constraint — but with the PHP floor at **`>=7.4`** per @rushi's review feedback on #14, instead of the `>=7.2` that PR had settled on.

Opened from a fork (`DzejlanRedzepefendic/OmnipayBundle`) rather than a branch on this repo.

## What changed vs #14

| File | #14 | This PR |
|---|---|---|
| `composer.json` → `require.php` | `>=7.2` | **`>=7.4`** |
| `.travis.yml` → `php:` matrix | `7.2, 7.3, 7.4` | **`7.4`** |
| `composer.json` → `require-dev.phpunit/phpunit` | `^8.5.52` | `^8.5.52` (unchanged) |

### Why `>=7.4` and not `>=7.2`

`phpunit/phpunit:^8.5.52` only *requires* PHP `>=7.2`, which is what #14 aligned to. But the transitive minimum of a dev dependency is the wrong thing to publish as our platform floor — `>=7.2` advertised support for 7.2 and 7.3, which we neither run in production nor exercise anywhere. `>=7.4` states the runtime we actually support. It is strictly narrower than phpunit's requirement, so there is no constraint conflict.

### Why `.travis.yml` moved too

Raising the floor to `>=7.4` while leaving `7.2`/`7.3` in the build matrix would leave the config self-contradictory: `composer install` now *rejects* the two versions the matrix claims to build against, so those legs could only ever fail. Trimming the matrix to `7.4` keeps the two files telling the same story.

Worth knowing: **Travis is not actually running on this repo** — the head commits of #14 have zero check-runs. So this edit is correctness-of-config, not a live CI fix. It is a 2-line deletion and trivially revertable if you would rather keep the matrix untouched and handle it separately.

## Packages upgraded

| Package | From | To | Scope | Alerts cleared |
|---|---|---|---|---|
| `phpunit/phpunit` | `^6` (resolved 6.5.14) | `^8.5.52` (resolves 8.5.54) | `require-dev` | 1 — [GHSA-vvj3-c3rp-c85p](https://github.com/advisories/GHSA-vvj3-c3rp-c85p) |

**Advisory**: PHPUnit vulnerable to unsafe deserialization in PHPT code coverage handling. Severity **high**. Vulnerable range `< 8.5.52`; first patched `8.5.52`.

The cross-major bump (6 → 8) is unavoidable: the highest release that exists on the 6.x line is `6.5.14`, still inside the vulnerable range, so there is no in-major fix. `composer.lock` is gitignored here, so the manifest constraint is the only available lever. Composer also drops five now-unneeded transitive dev packages that phpunit 6 pulled in and 8 does not, including the already-**abandoned** `phpunit/phpunit-mock-objects`.

## This PR also repairs a pre-existing failure on `master`

`master` is **currently red, independently of this change**. On PHP 7.4, phpunit 6.5's mock generator calls `ReflectionType::__toString()`, which 7.4 deprecated; `phpunit.xml.dist` sets `convertNoticesToExceptions="true"`, so each deprecation becomes a test error:

```
Function ReflectionType::__toString() is deprecated
  .../vendor/phpunit/phpunit-mock-objects/src/Generator.php:1089
```

Baseline on `origin/master`: **21 tests, 2 assertions, 19 errors.** On this branch: **21 tests, 72 assertions, 0 errors.** So this restores 70 assertions that were never actually reached before.

## Verification

Run locally on **PHP 7.4.33 / Composer 2.6.2**.

| Check | Result |
|---|---|
| `composer validate` | valid — 1 **pre-existing** warning (`symfony/framework-bundle` unbound `>=2.1`), unchanged by this PR |
| `composer install --no-scripts` | PASS |
| `vendor/bin/phpunit` | **OK (21 tests, 72 assertions)** |

**The `>=7.4` floor is enforced, not cosmetic.** Proven by overriding `config.platform.php` to 7.3.33 and re-resolving:

```
- Root composer.json requires php >=7.4 but your php version
  (7.3.33; overridden via config.platform, actual: 7.4.33) does not satisfy that requirement.
```

**Semver proof on the advisory**: baseline resolves `6.5.14`, which **satisfies** `< 8.5.52` → vulnerable, confirming the check is not vacuous. This branch resolves `8.5.54`, which does **not** satisfy `< 8.5.52` → cleared.

## Known cosmetic issue (deliberately not fixed here)

`phpunit.xml.dist:11` carries a `syntaxCheck` attribute that phpunit 8 rejects:

```
Warning - The configuration file did not pass validation!
  Line 11: - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.
```

The attribute was a no-op removed in phpunit 7. All 21 tests still run and pass. Left alone to keep this diff focused; **recommended follow-up** is to delete it.

## Residual

**0.** This was the only open high-severity Dependabot alert on the repo.

Fixes: https://app.vanta.com/c/xola.com/tests/packages-checked-for-vulnerabilities-v2-records-closed-github-dependabot-high

🤖 Generated with [Claude Code](https://claude.com/claude-code)
