### PR TITLE
PL-916 [Vanta] Remediate High vulnerabilities identified in packages are addressed (GitHub Repo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 composer.lock
 composer.phar
 phpunit.xml
+
+# PHPUnit
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     "homepage": "https://github.com/xola/OmnipayBundle",
     "license": "MIT",
     "require": {
-        "php": ">=7",
+        "php": ">=7.4",
         "symfony/framework-bundle": ">=2.1",
         "league/omnipay": "^3.0",
         "php-http/logger-plugin": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6",
+        "phpunit/phpunit": "^8.5.52",
         "omnipay/authorizenet": "^3.3",
         "omnipay/eway": "^3.0",
         "omnipay/mollie": "^5.2",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="Tests/bootstrap.php">
 
     <testsuites>


### PR DESCRIPTION
Remediates the PL-916 findings for this repo.

Supersedes #14 — same intent, opened from `master` so @anush's branch is left untouched. Difference: the `php` floor goes to `>=7.4` rather than `>=7.2`.

## Changes

| | before | after |
| --- | --- | --- |
| `php` | `>=7` | `>=7.4` |
| `phpunit/phpunit` | `^6` | `^8.5.52` |

PHPUnit `^6` is EOL and unpatched; `^8.5.52` is the newest release still supporting the PHP 7.x line. `>=7.4` matches the PHP version actually in use — the old floor (`>=7`) allowed PHP 7.0 onward, all long EOL and unable to receive security patches.

Also drops `syntaxCheck="false"` from `phpunit.xml.dist`. That attribute was removed from the PHPUnit 8 schema, so without this the bump makes the config fail validation — PHPUnit warns *"The configuration file did not pass validation! ... Test results may not be as expected"* on every run.

## Verification

This repo has no CI workflow, so everything below was run locally on **PHP 7.4.33 / Composer 2.6.2**:

- `composer validate` — valid (one pre-existing warning about the unbound `symfony/framework-bundle` constraint, not introduced here)
- `composer update --dry-run` — resolves cleanly; `phpunit/phpunit` locks to `8.5.54`
- `composer install` + `vendor/bin/phpunit` — **OK (21 tests, 72 assertions)**, and with the `syntaxCheck` removal the config warning is gone

No test needed changes for PHPUnit 8 — `Tests/` declares no `setUp`/`tearDown`, so the `: void` signature change does not apply.

## Note

`symfony/framework-bundle: ">=2.1"` is left as-is. It is unbound and still permits EOL Symfony 2.x/3.x, which is the more likely source of remaining high findings, but tightening it risks code changes in the bundle — better as its own ticket than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)